### PR TITLE
Remove avoid connection information

### DIFF
--- a/daemon/testutil/util.go
+++ b/daemon/testutil/util.go
@@ -24,7 +24,7 @@ func NewSQLMock(t *testing.T) (*sqlx.DB, sqlmock.Sqlmock) {
 
 // NewSQLConn returns connection with sql*x*.DB
 func NewSQLConn(t *testing.T) *sqlx.DB {
-	dbx, err := sqlx.Connect("mysql", "root:password@tcp(127.0.0.1)/testdb?parseTime=true&multiStatements=true")
+	dbx, err := sqlx.Connect("mysql", "root:password@tcp(127.0.0.1)/?parseTime=true&multiStatements=true")
 
 	if err != nil {
 		t.Fatalf("failed to connect to external db for test: %v", err)


### PR DESCRIPTION
its failed at first time (because there is no database which named `testdb`)